### PR TITLE
Use a more canonical way to detect the renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
-
 function isRenderer () {
-  return global && global.constructor && global.constructor.name === 'Window'
+  // node-integration is disabled
+  if (!process) return true;
+  
+  // We're in node.js somehow
+  if (!process.type) return false;
+  
+  return process.type === 'renderer';
 }
 
 module.exports = isRenderer()


### PR DESCRIPTION
Instead of using Window's string representation use a more canonical representation, similar to what Electron uses internally.
