### PR TITLE
Return false if it's being used in browser. (ref #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function isRenderer () {
-  // running in a web browser
-  if (typeof process === 'undefined') return true
+  // running in a web browser or in renderer without node integration.
+  if (typeof process === 'undefined') return false
   
   // node-integration is disabled
   if (!process) return true


### PR DESCRIPTION
Hi!

What I mean with my question it's a way to be able to make a distinction between a regular browser an the electron renderer process. So I think it should return false if it detects that it's being used in a browser. 
