### PR TITLE
Fixed running in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,4 +11,4 @@ function isRenderer () {
   return process.type === 'renderer'
 }
 
-module.exports = isRenderer()
+if (typeof module !== 'undefined') module.exports = isRenderer()


### PR DESCRIPTION
#2 was partially fixed by #3 ( checking if `process` is defined ), but it still couldn't be used in browsers because `module` is undefined. This fix would allow usage in browsers ( verified by pasting code into DevTools console, no errors would be thrown ).